### PR TITLE
fix(urdf): correct origin xyz/rpy values of link1 in mycobot_320_pi_2022

### DIFF
--- a/mycobot_description/urdf/mycobot_320_pi_2022/mycobot_320_pi_2022.urdf
+++ b/mycobot_description/urdf/mycobot_320_pi_2022/mycobot_320_pi_2022.urdf
@@ -33,7 +33,7 @@
      <geometry>
        <mesh filename="package://mycobot_description/urdf/mycobot_320_pi_2022/link1.dae"/>
       </geometry>
-      <origin xyz = "0.115 -0.172 -0.09 " rpy = " 0 0 3.1415926"/>
+      <origin xyz = "0.115 -0.172 -0.086 " rpy = " 0 0 3.1415926"/>
     </collision>
   </link>
 


### PR DESCRIPTION
Adjusted the origin definition to fix alignment issues in the URDF model.