### PR TITLE
fix: rosdep keys for ROS2 Humble (typos + message_runtime + warehouse_ros_mongo)

### DIFF
--- a/Mybuddy/mybuddy/package.xml
+++ b/Mybuddy/mybuddy/package.xml
@@ -21,8 +21,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>actionlib</exec_depend>
-  <exec_depend>join_state_publisher</exec_depend>
-  <exec_depend>join_state_publisher_gui</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>joy</exec_depend>

--- a/Mybuddy/mybuddy/package.xml
+++ b/Mybuddy/mybuddy/package.xml
@@ -10,7 +10,6 @@
   <build_depend>rclpy</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>actionlib</build_depend>
   <build_depend>mycobot_description</build_depend>
 
 
@@ -20,7 +19,6 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>actionlib</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ $ git clone -b foxy --depth 1 https://github.com/elephantrobotics/mycobot_ros2.g
 # For the galactic branch
 $ git clone -b galactic --depth 1 https://github.com/elephantrobotics/mycobot_ros2.git
 $ cd ~/colcon_ws
+$ vcs import src < src/warehouse_ros_mongo.repos
+$ sudo apt-get update && rosdep install --from-paths src --ignore-src -y
 $ colcon build
 $ source ~/colcon_ws/install/setup.bash
 $ sudo echo 'source ~/colcon_ws/install/setup.bash' >> ~/.bashrc

--- a/mecharm/mecharm/package.xml
+++ b/mecharm/mecharm/package.xml
@@ -21,8 +21,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>actionlib</exec_depend>
-  <exec_depend>join_state_publisher</exec_depend>
-  <exec_depend>join_state_publisher_gui</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>joy</exec_depend>

--- a/mecharm/mecharm/package.xml
+++ b/mecharm/mecharm/package.xml
@@ -10,7 +10,6 @@
   <build_depend>rclpy</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>actionlib</build_depend>
   <build_depend>mycobot_description</build_depend>
 
 
@@ -20,7 +19,6 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>actionlib</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/mecharm/mecharm_communication/package.xml
+++ b/mecharm/mecharm_communication/package.xml
@@ -11,12 +11,11 @@
 
   <build_depend>rclpy</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>message_generation</build_depend>
   <build_depend>mycobot_interfaces</build_depend>
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>mycobot_interfaces</exec_depend>
 
   <build_export_depend>mycobot_interfaces</build_export_depend>

--- a/mecharm/mecharm_communication/package.xml
+++ b/mecharm/mecharm_communication/package.xml
@@ -7,8 +7,6 @@
   <maintainer email="u20@todo.todo">u20</maintainer>
   <license>TODO: License declaration</license>
 
-    <buildtool_depend>ament_python</buildtool_depend>
-
   <build_depend>rclpy</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>mycobot_interfaces</build_depend>

--- a/mecharm/mecharm_interfaces/package.xml
+++ b/mecharm/mecharm_interfaces/package.xml
@@ -8,18 +8,16 @@
   <license>TODO: License declaration</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
-  <build_depend>rosidl_default_generators</build_depend>
   <build_depend>rclpy</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>message_generation</build_depend>
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>message_runtime</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>

--- a/mecharm/mecharm_pi/package.xml
+++ b/mecharm/mecharm_pi/package.xml
@@ -20,8 +20,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>actionlib</exec_depend>
-  <exec_depend>join_state_publisher</exec_depend>
-  <exec_depend>join_state_publisher_gui</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>joy</exec_depend>

--- a/mecharm/mecharm_pi/package.xml
+++ b/mecharm/mecharm_pi/package.xml
@@ -10,7 +10,6 @@
   <build_depend>rclpy</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>actionlib</build_depend>
   <build_depend>mycobot_description</build_depend>
 
   <build_export_depend>mycobot_description</build_export_depend>
@@ -19,7 +18,6 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>actionlib</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/myArm/myarm_300/package.xml
+++ b/myArm/myarm_300/package.xml
@@ -21,8 +21,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>actionlib</exec_depend>
-  <exec_depend>join_state_publisher</exec_depend>
-  <exec_depend>join_state_publisher_gui</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>joy</exec_depend>

--- a/myArm/myarm_300/package.xml
+++ b/myArm/myarm_300/package.xml
@@ -10,7 +10,6 @@
   <build_depend>rclpy</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>actionlib</build_depend>
   <build_depend>mycobot_description</build_depend>
 
 
@@ -20,7 +19,6 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>actionlib</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/myArm/myarm_c650/package.xml
+++ b/myArm/myarm_c650/package.xml
@@ -24,8 +24,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>actionlib</exec_depend>
-  <exec_depend>join_state_publisher</exec_depend>
-  <exec_depend>join_state_publisher_gui</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>joy</exec_depend>

--- a/myArm/myarm_c650/package.xml
+++ b/myArm/myarm_c650/package.xml
@@ -10,7 +10,6 @@
   <build_depend>rclpy</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>actionlib</build_depend>
   <build_depend>mycobot_communication</build_depend>
   <build_depend>mycobot_description</build_depend>
 
@@ -23,7 +22,6 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>actionlib</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/myArm/myarm_m750/package.xml
+++ b/myArm/myarm_m750/package.xml
@@ -24,8 +24,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>actionlib</exec_depend>
-  <exec_depend>join_state_publisher</exec_depend>
-  <exec_depend>join_state_publisher_gui</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>joy</exec_depend>

--- a/myArm/myarm_m750/package.xml
+++ b/myArm/myarm_m750/package.xml
@@ -10,7 +10,6 @@
   <build_depend>rclpy</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>actionlib</build_depend>
   <build_depend>mycobot_communication</build_depend>
   <build_depend>mycobot_description</build_depend>
 
@@ -23,7 +22,6 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>actionlib</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/mycobot_280/mycobot_280/package.xml
+++ b/mycobot_280/mycobot_280/package.xml
@@ -21,8 +21,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>actionlib</exec_depend>
-  <exec_depend>join_state_publisher</exec_depend>
-  <exec_depend>join_state_publisher_gui</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>joy</exec_depend>

--- a/mycobot_280/mycobot_280/package.xml
+++ b/mycobot_280/mycobot_280/package.xml
@@ -10,7 +10,6 @@
   <build_depend>rclpy</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>actionlib</build_depend>
   <build_depend>mycobot_description</build_depend>
 
 
@@ -20,7 +19,6 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>actionlib</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/mycobot_280/mycobot_280_arduino/package.xml
+++ b/mycobot_280/mycobot_280_arduino/package.xml
@@ -21,8 +21,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>actionlib</exec_depend>
-  <exec_depend>join_state_publisher</exec_depend>
-  <exec_depend>join_state_publisher_gui</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>joy</exec_depend>

--- a/mycobot_280/mycobot_280_arduino/package.xml
+++ b/mycobot_280/mycobot_280_arduino/package.xml
@@ -10,7 +10,6 @@
   <build_depend>rclpy</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>actionlib</build_depend>
   <build_depend>mycobot_description</build_depend>
 
 
@@ -20,7 +19,6 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>actionlib</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/mycobot_280/mycobot_280_moveit2_control/package.xml
+++ b/mycobot_280/mycobot_280_moveit2_control/package.xml
@@ -21,8 +21,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>actionlib</exec_depend>
-  <exec_depend>join_state_publisher</exec_depend>
-  <exec_depend>join_state_publisher_gui</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>joy</exec_depend>

--- a/mycobot_280/mycobot_280_moveit2_control/package.xml
+++ b/mycobot_280/mycobot_280_moveit2_control/package.xml
@@ -10,7 +10,6 @@
   <build_depend>rclpy</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>actionlib</build_depend>
   <build_depend>mycobot_description</build_depend>
 
 
@@ -20,7 +19,6 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>actionlib</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/mycobot_280/mycobot_280_rdkx5/package.xml
+++ b/mycobot_280/mycobot_280_rdkx5/package.xml
@@ -10,7 +10,6 @@
   <build_depend>rclpy</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>actionlib</build_depend>
   <build_depend>mycobot_communication</build_depend>
   <build_depend>mycobot_description</build_depend>
 
@@ -21,7 +20,6 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>actionlib</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/mycobot_280/mycobot_280_rdkx5/package.xml
+++ b/mycobot_280/mycobot_280_rdkx5/package.xml
@@ -22,8 +22,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>actionlib</exec_depend>
-  <exec_depend>join_state_publisher</exec_depend>
-  <exec_depend>join_state_publisher_gui</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>joy</exec_depend>

--- a/mycobot_280/mycobot_280_riscv/package.xml
+++ b/mycobot_280/mycobot_280_riscv/package.xml
@@ -21,8 +21,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>actionlib</exec_depend>
-  <exec_depend>join_state_publisher</exec_depend>
-  <exec_depend>join_state_publisher_gui</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>joy</exec_depend>

--- a/mycobot_280/mycobot_280_riscv/package.xml
+++ b/mycobot_280/mycobot_280_riscv/package.xml
@@ -10,7 +10,6 @@
   <build_depend>rclpy</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>actionlib</build_depend>
   <build_depend>mycobot_description</build_depend>
 
 
@@ -20,7 +19,6 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>actionlib</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/mycobot_280/mycobot_280_x3pi/package.xml
+++ b/mycobot_280/mycobot_280_x3pi/package.xml
@@ -20,8 +20,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>actionlib</exec_depend>
-  <exec_depend>join_state_publisher</exec_depend>
-  <exec_depend>join_state_publisher_gui</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>joy</exec_depend>

--- a/mycobot_280/mycobot_280_x3pi/package.xml
+++ b/mycobot_280/mycobot_280_x3pi/package.xml
@@ -10,7 +10,6 @@
   <build_depend>rclpy</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>actionlib</build_depend>
   <build_depend>mycobot_description</build_depend>
 
   <build_export_depend>mycobot_description</build_export_depend>
@@ -19,7 +18,6 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>actionlib</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/mycobot_280/mycobot_280jn/package.xml
+++ b/mycobot_280/mycobot_280jn/package.xml
@@ -21,8 +21,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>actionlib</exec_depend>
-  <exec_depend>join_state_publisher</exec_depend>
-  <exec_depend>join_state_publisher_gui</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>joy</exec_depend>

--- a/mycobot_280/mycobot_280jn/package.xml
+++ b/mycobot_280/mycobot_280jn/package.xml
@@ -10,7 +10,6 @@
   <build_depend>rclpy</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>actionlib</build_depend>
   <build_depend>mycobot_description</build_depend>
 
 
@@ -20,7 +19,6 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>actionlib</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/mycobot_280/mycobot_280pi/package.xml
+++ b/mycobot_280/mycobot_280pi/package.xml
@@ -21,8 +21,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>actionlib</exec_depend>
-  <exec_depend>join_state_publisher</exec_depend>
-  <exec_depend>join_state_publisher_gui</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>joy</exec_depend>

--- a/mycobot_280/mycobot_280pi/package.xml
+++ b/mycobot_280/mycobot_280pi/package.xml
@@ -10,7 +10,6 @@
   <build_depend>rclpy</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>actionlib</build_depend>
   <build_depend>mycobot_description</build_depend>
 
 
@@ -20,7 +19,6 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>actionlib</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/mycobot_280/mycobot_interfaces/package.xml
+++ b/mycobot_280/mycobot_interfaces/package.xml
@@ -8,18 +8,16 @@
   <license>TODO: License declaration</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
-  <build_depend>rosidl_default_generators</build_depend>
   <build_depend>rclpy</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>message_generation</build_depend>
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>message_runtime</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>

--- a/mycobot_320/mycobot_320/package.xml
+++ b/mycobot_320/mycobot_320/package.xml
@@ -20,8 +20,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>actionlib</exec_depend>
-  <exec_depend>join_state_publisher</exec_depend>
-  <exec_depend>join_state_publisher_gui</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>joy</exec_depend>

--- a/mycobot_320/mycobot_320/package.xml
+++ b/mycobot_320/mycobot_320/package.xml
@@ -10,7 +10,6 @@
   <build_depend>rclpy</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>actionlib</build_depend>
   <build_depend>mycobot_description</build_depend>
 
   <build_export_depend>mycobot_description</build_export_depend>
@@ -19,7 +18,6 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>actionlib</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/mycobot_320/mycobot_320_riscv/package.xml
+++ b/mycobot_320/mycobot_320_riscv/package.xml
@@ -21,8 +21,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>actionlib</exec_depend>
-  <exec_depend>join_state_publisher</exec_depend>
-  <exec_depend>join_state_publisher_gui</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>joy</exec_depend>

--- a/mycobot_320/mycobot_320_riscv/package.xml
+++ b/mycobot_320/mycobot_320_riscv/package.xml
@@ -10,7 +10,6 @@
   <build_depend>rclpy</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>actionlib</build_depend>
   <build_depend>mycobot_description</build_depend>
 
 
@@ -20,7 +19,6 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>actionlib</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/mycobot_320/mycobot_320pi/package.xml
+++ b/mycobot_320/mycobot_320pi/package.xml
@@ -21,8 +21,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>actionlib</exec_depend>
-  <exec_depend>join_state_publisher</exec_depend>
-  <exec_depend>join_state_publisher_gui</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>joy</exec_depend>

--- a/mycobot_320/mycobot_320pi/package.xml
+++ b/mycobot_320/mycobot_320pi/package.xml
@@ -10,7 +10,6 @@
   <build_depend>rclpy</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>actionlib</build_depend>
   <build_depend>mycobot_description</build_depend>
 
 
@@ -20,7 +19,6 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>actionlib</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/mycobot_communication/package.xml
+++ b/mycobot_communication/package.xml
@@ -7,8 +7,6 @@
   <maintainer email="u2@todo.todo">u2</maintainer>
   <license>BSD</license>
 
-  <buildtool_depend>ament_python</buildtool_depend>
-
   <build_depend>rclpy</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>mycobot_interfaces</build_depend>

--- a/mycobot_communication/package.xml
+++ b/mycobot_communication/package.xml
@@ -11,12 +11,10 @@
 
   <build_depend>rclpy</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>message_generation</build_depend>
   <build_depend>mycobot_interfaces</build_depend>
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>message_runtime</exec_depend>
   <exec_depend>mycobot_interfaces</exec_depend>
 
   <build_export_depend>mycobot_interfaces</build_export_depend>

--- a/mycobot_pro/mycobot_600/package.xml
+++ b/mycobot_pro/mycobot_600/package.xml
@@ -21,8 +21,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>actionlib</exec_depend>
-  <exec_depend>join_state_publisher</exec_depend>
-  <exec_depend>join_state_publisher_gui</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>joy</exec_depend>

--- a/mycobot_pro/mycobot_600/package.xml
+++ b/mycobot_pro/mycobot_600/package.xml
@@ -10,7 +10,6 @@
   <build_depend>rclpy</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>actionlib</build_depend>
   <build_depend>mycobot_description</build_depend>
 
 
@@ -20,7 +19,6 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>actionlib</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/mycobot_pro/mycobot_630/package.xml
+++ b/mycobot_pro/mycobot_630/package.xml
@@ -21,8 +21,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>actionlib</exec_depend>
-  <exec_depend>join_state_publisher</exec_depend>
-  <exec_depend>join_state_publisher_gui</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>joy</exec_depend>

--- a/mycobot_pro/mycobot_630/package.xml
+++ b/mycobot_pro/mycobot_630/package.xml
@@ -10,7 +10,6 @@
   <build_depend>rclpy</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>actionlib</build_depend>
   <build_depend>mycobot_description</build_depend>
 
 
@@ -20,7 +19,6 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>actionlib</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/mycobot_pro/mycobot_pro450_interfaces/package.xml
+++ b/mycobot_pro/mycobot_pro450_interfaces/package.xml
@@ -8,18 +8,16 @@
   <license>TODO: License declaration</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
-  <build_depend>rosidl_default_generators</build_depend>
   <build_depend>rclpy</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>message_generation</build_depend>
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>message_runtime</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>

--- a/mycobot_pro/mycobot_pro_450/package.xml
+++ b/mycobot_pro/mycobot_pro_450/package.xml
@@ -20,8 +20,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>actionlib</exec_depend>
-  <exec_depend>join_state_publisher</exec_depend>
-  <exec_depend>join_state_publisher_gui</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>joy</exec_depend>

--- a/mycobot_pro/mycobot_pro_450/package.xml
+++ b/mycobot_pro/mycobot_pro_450/package.xml
@@ -10,7 +10,6 @@
   <build_depend>rclpy</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>actionlib</build_depend>
   <build_depend>mycobot_description</build_depend>
 
   <build_export_depend>mycobot_description</build_export_depend>
@@ -19,7 +18,6 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>actionlib</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/mycobot_pro/pro450_moveit2_control/package.xml
+++ b/mycobot_pro/pro450_moveit2_control/package.xml
@@ -21,8 +21,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>actionlib</exec_depend>
-  <exec_depend>join_state_publisher</exec_depend>
-  <exec_depend>join_state_publisher_gui</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>joy</exec_depend>

--- a/mycobot_pro/pro450_moveit2_control/package.xml
+++ b/mycobot_pro/pro450_moveit2_control/package.xml
@@ -10,7 +10,6 @@
   <build_depend>rclpy</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>actionlib</build_depend>
   <build_depend>mycobot_description</build_depend>
 
 
@@ -20,7 +19,6 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>actionlib</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/mypalletizer_260/mypalletizer_260/package.xml
+++ b/mypalletizer_260/mypalletizer_260/package.xml
@@ -20,8 +20,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>actionlib</exec_depend>
-  <exec_depend>join_state_publisher</exec_depend>
-  <exec_depend>join_state_publisher_gui</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>joy</exec_depend>

--- a/mypalletizer_260/mypalletizer_260/package.xml
+++ b/mypalletizer_260/mypalletizer_260/package.xml
@@ -10,7 +10,6 @@
   <build_depend>rclpy</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>actionlib</build_depend>
   <build_depend>mycobot_description</build_depend>
 
   <build_export_depend>mycobot_description</build_export_depend>
@@ -19,7 +18,6 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>actionlib</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/mypalletizer_260/mypalletizer_260_pi/package.xml
+++ b/mypalletizer_260/mypalletizer_260_pi/package.xml
@@ -21,8 +21,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>actionlib</exec_depend>
-  <exec_depend>join_state_publisher</exec_depend>
-  <exec_depend>join_state_publisher_gui</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>joy</exec_depend>

--- a/mypalletizer_260/mypalletizer_260_pi/package.xml
+++ b/mypalletizer_260/mypalletizer_260_pi/package.xml
@@ -10,7 +10,6 @@
   <build_depend>rclpy</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>actionlib</build_depend>
   <build_depend>mycobot_description</build_depend>
 
 
@@ -20,7 +19,6 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>actionlib</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/mypalletizer_260/mypalletizer_communication/package.xml
+++ b/mypalletizer_260/mypalletizer_communication/package.xml
@@ -7,8 +7,6 @@
   <maintainer email="u20@todo.todo">u20</maintainer>
   <license>TODO: License declaration</license>
 
-    <buildtool_depend>ament_python</buildtool_depend>
-
   <build_depend>rclpy</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>mypalletizer_interfaces</build_depend>

--- a/mypalletizer_260/mypalletizer_communication/package.xml
+++ b/mypalletizer_260/mypalletizer_communication/package.xml
@@ -11,12 +11,11 @@
 
   <build_depend>rclpy</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>message_generation</build_depend>
   <build_depend>mypalletizer_interfaces</build_depend>
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>mypalletizer_interfaces</exec_depend>
 
   <build_export_depend>mypalletizer_interfaces</build_export_depend>

--- a/mypalletizer_260/mypalletizer_interfaces/package.xml
+++ b/mypalletizer_260/mypalletizer_interfaces/package.xml
@@ -8,18 +8,16 @@
   <license>TODO: License declaration</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
-  <build_depend>rosidl_default_generators</build_depend>
   <build_depend>rclpy</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>message_generation</build_depend>
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>message_runtime</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>

--- a/ultraArm/ultraarm/package.xml
+++ b/ultraArm/ultraarm/package.xml
@@ -21,8 +21,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>actionlib</exec_depend>
-  <exec_depend>join_state_publisher</exec_depend>
-  <exec_depend>join_state_publisher_gui</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
   <exec_depend>joy</exec_depend>

--- a/ultraArm/ultraarm/package.xml
+++ b/ultraArm/ultraarm/package.xml
@@ -10,7 +10,6 @@
   <build_depend>rclpy</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>actionlib</build_depend>
   <build_depend>mycobot_description</build_depend>
 
 
@@ -20,7 +19,6 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>actionlib</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/warehouse_ros_mongo.repos
+++ b/warehouse_ros_mongo.repos
@@ -1,0 +1,11 @@
+# warehouse_ros_mongo - MongoDB backend for MoveIt scene/state storage
+# Required by: mycobot_*_moveit2, pro450_moveit2, mycobot_630_moveit2
+# Not available as ros-humble-warehouse-ros-mongo apt package; build from source.
+#
+# Usage (from workspace root): vcs import src < src/warehouse_ros_mongo.repos
+#
+repositories:
+  warehouse_ros_mongo:
+    type: git
+    url: https://github.com/ros-planning/warehouse_ros_mongo.git
+    version: ros2


### PR DESCRIPTION
## Summary

Fixes `rosdep install --from-paths src --ignore-src -y` failing on the Humble branch due to invalid rosdep keys and a missing dependency that has no apt package.

## What was fixed

### 1. `join_state_publisher_gui` → `joint_state_publisher_gui`

Many `package.xml` files used the typo **`join_state_publisher_gui`** instead of the correct rosdep key **`joint_state_publisher_gui`**, which caused:

- **ERROR:** `Cannot locate rosdep definition for [join_state_publisher_gui]`

**Fix:** Corrected the dependency name to `joint_state_publisher_gui` in all affected packages (mycobot_280pi, mycobot_pro_450, mypalletizer_260, mecharm, ultraarm, pro450_moveit2_control, mycobot_320pi, mycobot_320, mycobot_280_rdkx5, mycobot_280_riscv, mycobot_280, myarm_300, mycobot_630, myarm_c650, mypalletizer_260_pi, mycobot_280_arduino, mycobot_280_moveit2_control, mycobot_280jn, mycobot_280_x3pi, myarm_m750, mycobot_600, mybuddy, mycobot_320_riscv, mecharm_pi, and related packages).

### 2. `message_runtime` → `rosidl_default_runtime` (ROS2 interfaces)

Interface and communication packages listed **`message_runtime`**, which is a ROS1 rosdep key and is not valid for ROS2, causing:

- **ERROR:** `Cannot locate rosdep definition for [message_runtime]`

**Fix:** Replaced `message_runtime` with **`rosidl_default_runtime`** and aligned rosidl/interface dependencies for ROS2 in: mycobot_pro450_interfaces, mycobot_interfaces, mecharm_interfaces, mypalletizer_interfaces, mycobot_communication, mecharm_communication, mypalletizer_communication.

### 3. warehouse_ros_mongo and `warehouse_ros_mongo.repos`

MoveIt2 packages (e.g. `mycobot_*_moveit2`, `pro450_moveit2`, `mycobot_630_moveit2`) depend on **warehouse_ros_mongo** for scene/state storage. There is **no** `ros-humble-warehouse-ros-mongo` (or equivalent) package in the official ROS 2 apt repositories, so rosdep cannot install it and the package is not a valid system dependency from apt.

**Fix:** Added **`warehouse_ros_mongo.repos`** so the workspace can pull and build `warehouse_ros_mongo` from source (`ros-planning/warehouse_ros_mongo`, branch `ros2`). The README was updated to run **`vcs import src < src/warehouse_ros_mongo.repos`** before **`rosdep install --from-paths src --ignore-src -y`** and **`colcon build`**, so the dependency is present before build and rosdep no longer fails on it.

## Other changes in this branch

- Removed invalid `ament_python` buildtool dependency from `package.xml` files where applicable.
- Removed ROS1 `actionlib` dependency from ROS2 Humble packages.

## How to verify

From workspace root (e.g. `~/colcon_ws`):
bash
```
vcs import src < src/warehouse_ros_mongo.repos
sudo apt-get update && rosdep install --from-paths src --ignore-src -y
colcon build
```

`rosdep install` should complete without errors.