### PR TITLE
Declare myCobot 280 controller runtime dependencies

### DIFF
--- a/mycobot_280/mycobot_280_moveit2/package.xml
+++ b/mycobot_280/mycobot_280_moveit2/package.xml
@@ -22,13 +22,13 @@
   <exec_depend>moveit_kinematics</exec_depend>
   <exec_depend>moveit_planners</exec_depend>
   <exec_depend>moveit_simple_controller_manager</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
+  <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>xacro</exec_depend>
-  <!-- The next 2 packages are required for the gazebo simulation.
-       We don't include them by default to prevent installing gazebo and all its dependencies. -->
-  <!-- <exec_depend>joint_trajectory_controller</exec_depend> -->
+  <!-- Gazebo is optional to avoid pulling in the simulator and all of its dependencies. -->
   <!-- <exec_depend>gazebo_ros_control</exec_depend> -->
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>moveit_configs_utils</exec_depend>


### PR DESCRIPTION
## Summary

- declare `joint_state_broadcaster` as a runtime dependency of `mycobot_280_moveit2`
- declare `joint_trajectory_controller`, which the package's `ros2_controllers.yaml` loads at runtime
- keep Gazebo optional

This lets dependency installation provide the controller plugins that `demo.launch.py` expects instead of leaving `controller_manager` with only its test plugins.

Fixes #57.

## Testing

- validated `package.xml` with `xmllint`
- checked that every controller plugin prefix referenced by `config/ros2_controllers.yaml` is present in `exec_depend`
- `git diff --check`